### PR TITLE
Enable fruitwars mode

### DIFF
--- a/FruitBot/FruitBot.csproj
+++ b/FruitBot/FruitBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!--<DefineConstants>FRUITWARSMODE</DefineConstants>-->
+		<DefineConstants>FRUITWARSMODE</DefineConstants>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net7.0</TargetFramework>
 		<PublishSingleFile>true</PublishSingleFile>

--- a/FruitPantry/FruitPantry.csproj
+++ b/FruitPantry/FruitPantry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<!--<DefineConstants>FRUITWARSMODE</DefineConstants>-->
+		<DefineConstants>FRUITWARSMODE</DefineConstants>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net7.0</TargetFramework>
 		<PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
scheduling merge to be applied on Jan. 19, 2024 at 23:56, 4 minutes before the start of Fruit Wars 
4 minute buffer:
- 2 minutes to merge and publish
- 2 minutes lead time to ensure startup & firing of schedule-based actions in app (leaderboard initial post)